### PR TITLE
Finished parsing the accelerator data and fixed a vendor specific print alignment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ NVME_DPKG_VERSION=1~`lsb_release -sc`
 
 OBJS := argconfig.o suffix.o parser.o nvme-print.o nvme-ioctl.o \
 	nvme-lightnvm.o fabrics.o json.o plugin.o intel-nvme.o \
-	lnvm-nvme.o memblaze-nvme.o wdc-nvme.o nvme-models.o huawei-nvme.o
+	lnvm-nvme.o memblaze-nvme.o wdc-nvme.o nvme-models.o \
+	huawei-nvme.o eid-nvme.o
 
 nvme: nvme.c nvme.h $(OBJS) NVME-VERSION-FILE
 	$(CC) $(CPPFLAGS) $(CFLAGS) nvme.c -o $(NVME) $(OBJS) $(LDFLAGS)

--- a/eid-nvme.c
+++ b/eid-nvme.c
@@ -49,7 +49,7 @@ struct eid_noload {
 	char             hls[12];
 	char             acc_name[64];
 	__le32           acc_ver;
-	char             acc_cfg[24];
+	__le32           acc_cfg[6];
 	__le32           acc_priv_len;
 	char             acc_priv[3600];
 };
@@ -68,8 +68,8 @@ static void eid_print_list_item(struct list_item list_item)
 		(struct eid_noload *) &list_item.ns.vs;
 	
 	printf("%-16s %-64.64s %-8.8u 0x%-8.8x\n", list_item.node,
-	       eid->acc_name, (unsigned int) eid->acc_ver,
-	       (unsigned int) eid->acc_status);
+				 eid->acc_name, (unsigned int) eid->acc_ver,
+				 (unsigned int) eid->acc_status);
 }
 
 static void eid_print_list_items(struct list_item *list_items, unsigned len)
@@ -77,28 +77,89 @@ static void eid_print_list_items(struct list_item *list_items, unsigned len)
 	unsigned i;
 
 	printf("%-16s %-64s %-8s %-10s\n",
-	       "Node", "Accelerator Name", "Version", "Status");
+				 "Node", "Accelerator Name", "Version", "Status");
 	printf("%-16s %-64s %-8s %-10s\n",
-	       "----------------",
-	       "----------------------------------------------------------------",
-	       "--------", "----------");
+				 "----------------",
+				 "----------------------------------------------------------------",
+				 "--------", "----------");
 	for (i = 0 ; i < len ; i++)
 		eid_print_list_item(list_items[i]);
 }
 
-static void eid_show_nvme_id_ns(struct nvme_id_ns *ns)
+static void eid_show_nvme_id_ns_status(__le32 status)
 {
+	__u16 upper_rsvd = (status & 0xFFFE0000) >> 17;
+	__u16 lower_rsvd = (status & 0x000000F8) >> 3;
+	int as_en = status & 0x1; // Bit 0 boolean
+	int as_rdrdy = (status & 0x2) >> 1; // Bit 1 boolean
+	int as_wrrdy = (status & 0x4) >> 2; // Bit 2 boolean 
+	__u8 as_err = (status & 0xFF00) >> 8; // Bits 15:8
+	int as_async = (status & 0x10000) >> 16; // Bit 16 boolean
+
+	if (upper_rsvd)
+		printf("\t[31:17]\t: 0x%x\tReserved\n", upper_rsvd);
+
+	printf("\t[16:16]\t: %#x\tAsync Event Request ", as_async);
+	if(as_async)
+		printf("enabled ");
+	else
+		printf("disabled ");
+	printf("(AS.ASYNC)\n");
+
+	if(as_err)
+		printf("\t[15:8]\t: %d\tError 0x%x occurred ", as_err, as_err);
+	else
+		printf("\t[15:8]\t: %d\tNo errors have been reported ", as_err);
+	printf("(AS.ERR)\n");
+
+	if(lower_rsvd)
+		printf("\t[7:3]\t: 0x%x\tReserved\n", lower_rsvd);
+
+	if(as_wrrdy)
+		printf("\t[2:2]\t: %d\tAccelerator is ready for the next write command ", as_wrrdy);
+	else
+		printf("\t[2:2]\t: %d\tAccelerator is NOT ready for the next write command ", as_wrrdy);
+	printf("(AS.WRRDY)\n");
+
+	if(as_rdrdy)
+		printf("\t[1:1]\t: %d\tAccelerator is ready for the next read command ", as_rdrdy);
+	else
+		printf("\t[1:1]\t: %d\tAccelerator is NOT ready for the next read command ", as_rdrdy);
+	printf("(AS.RDRDY)\n");
+
+	if(as_en)
+		printf("\t[0:0]\t: %d\tAccelerator is enabled ", as_en);
+	else
+		printf("\t[0:0]\t: %d\tAccelerator is NOT enabled ", as_en);
+	printf("(AS.EN)\n\n");
+}
+
+static void eid_show_nvme_id_ns(struct nvme_id_ns *ns, unsigned int mode)
+{
+	unsigned i;
+	int human = mode & HUMAN;
 	struct eid_noload *eid =
 		(struct eid_noload *) &ns->vs;
 
-	printf("acc_status : 0x%-8.8x\n", eid->acc_status);
-	printf("acc_name   : %s\n", eid->acc_name);
+	printf("acc_name\t: %s\n", eid->acc_name);
+	printf("acc_status\t: 0x%-8.8x\n", eid->acc_status);
+	if (human)
+		eid_show_nvme_id_ns_status(eid->acc_status);
+	printf("acc_version\t: %-8.8d\n", eid->acc_ver);
+	for(i = 0; i < 24/4; ++i)
+		printf("acc_cfg[%d]\t: 0x%-8.8x\n", i, eid->acc_cfg[i]);
+	printf("acc_spec_bytes\t: %d\n", eid->acc_priv_len);
+	if(eid->acc_priv_len)
+	{
+		printf("acc_user_space\t:\n");
+		d((unsigned char *)eid->acc_priv, eid->acc_priv_len, 16, 1);
+	}
+
 //	char             hls[12];
 //	char             acc_name[64];
 //	__le32           acc_ver;
 //	char             acc_cfg[24];
 //	__le32           acc_priv_len;
-
 }
 
 
@@ -109,7 +170,7 @@ static void eid_show_nvme_id_ns(struct nvme_id_ns *ns)
  */
 
 static int eid_list(int argc, char **argv, struct command *command,
-		    struct plugin *plugin)
+				struct plugin *plugin)
 {
 	char path[264];
 	struct dirent **devices;
@@ -175,19 +236,22 @@ static int eid_list(int argc, char **argv, struct command *command,
 }
 
 static int eid_id_ns(int argc, char **argv, struct command *command,
-		     struct plugin *plugin)
+				 struct plugin *plugin)
 {
 	const char *desc = "Send an Identify Namespace command to the "\
-		"given device, returns properties of the specified namespace "\
-		"in human-readable format. Fails on non-Eideticom namespaces";
+		"given device, returns properties of the specified namespace. "\
+		"Fails on non-Eideticom namespaces.";
 	const char *namespace_id = "identifier of desired namespace";
+	const char *human_readable = "show infos in readable format";
 	struct nvme_id_ns ns;
 	struct stat nvme_stat;
+	unsigned int flags = 0;
 
 	int err, fd;
 
 	struct config {
 		__u32 namespace_id;
+		int human_readable;
 	};
 
 	struct config cfg = {
@@ -195,7 +259,8 @@ static int eid_id_ns(int argc, char **argv, struct command *command,
 	};
 
 	const struct argconfig_commandline_options command_line_options[] = {
-		{"namespace-id",    'n', "NUM", CFG_POSITIVE, &cfg.namespace_id,    required_argument, namespace_id},
+		{"namespace-id", 'n', "NUM", CFG_POSITIVE, &cfg.namespace_id, required_argument, namespace_id},
+		{"human-readable", 'H', "", CFG_NONE, &cfg.human_readable, no_argument, human_readable},
 		{NULL}
 	};
 
@@ -213,10 +278,13 @@ static int eid_id_ns(int argc, char **argv, struct command *command,
 		fprintf(stderr,
 			"Error: requesting namespace-id from non-block device\n");
 
+	if (cfg.human_readable)
+			flags |= HUMAN;
+
 	err = nvme_identify_ns(fd, cfg.namespace_id, 0, &ns);
 	if (!err) {
 		printf("NVME Identify Namespace %d:\n", cfg.namespace_id);
-		eid_show_nvme_id_ns(&ns);
+		eid_show_nvme_id_ns(&ns, flags);
 	}
 	else if (err > 0)
 		fprintf(stderr, "NVMe Status:%s(%x) NSID:%d\n",

--- a/eid-nvme.c
+++ b/eid-nvme.c
@@ -26,6 +26,7 @@
 #include <limits.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <sys/stat.h>
 
 #include "linux/nvme_ioctl.h"
 
@@ -41,16 +42,186 @@
 #define CREATE_CMD
 #include "eid-nvme.h"
 
+static const char *dev = "/dev/";
+
+struct eid_noload {
+	__le32           acc_status;
+	char             hls[12];
+	char             acc_name[64];
+	__le32           acc_ver;
+	char             acc_cfg[24];
+	__le32           acc_priv_len;
+	char             acc_priv[3600];
+};
+
+static unsigned eid_check_item(struct list_item *item)
+{
+	if (strstr(item->ctrl.mn, "Eideticom") == NULL)
+		return 0;
+
+	return 1;
+}
+
+static void eid_print_list_item(struct list_item list_item)
+{
+	struct eid_noload *eid =
+		(struct eid_noload *) &list_item.ns.vs;
+	
+	printf("%-16s %-64.64s %-8.8u 0x%-8.8x\n", list_item.node,
+	       eid->acc_name, (unsigned int) eid->acc_ver,
+	       (unsigned int) eid->acc_status);
+}
+
+static void eid_print_list_items(struct list_item *list_items, unsigned len)
+{
+	unsigned i;
+
+	printf("%-16s %-64s %-8s %-10s\n",
+	       "Node", "Accelerator Name", "Version", "Status");
+	printf("%-16s %-64s %-8s %-10s\n",
+	       "----------------",
+	       "----------------------------------------------------------------",
+	       "--------", "----------");
+	for (i = 0 ; i < len ; i++)
+		eid_print_list_item(list_items[i]);
+}
+
+static void eid_show_nvme_id_ns(struct nvme_id_ns *ns)
+{
+	struct eid_noload *eid =
+		(struct eid_noload *) &ns->vs;
+
+	printf("acc_status : 0x%-8.8x\n", eid->acc_status);
+	printf("acc_name   : %s\n", eid->acc_name);
+//	char             hls[12];
+//	char             acc_name[64];
+//	__le32           acc_ver;
+//	char             acc_cfg[24];
+//	__le32           acc_priv_len;
+
+}
+
+
+/*
+ * List all the Eideticom namespaces in the system and identify the
+ * accerlation functio provided by that namespace. We base this off
+ * the Huawei code. Ideally we'd refactor this a bit. That is a TBD. 
+ */
+
 static int eid_list(int argc, char **argv, struct command *command,
 		    struct plugin *plugin)
 {
-	fprintf(stderr, "%s\n", __func__);
+	char path[264];
+	struct dirent **devices;
+	struct list_item *list_items;
+	unsigned int i, n, fd, ret, eid_num;
+	int fmt;
+	
+	const char *desc = "Retrieve basic information for any Eideticom " \
+		"namespaces in the systrem";
+	struct config {
+		char *output_format;
+	};
+	struct config cfg = {
+		.output_format = "normal",
+	};
+
+	const struct argconfig_commandline_options opts[] = {
+		{"output-format", 'o', "FMT", CFG_STRING, &cfg.output_format, required_argument, "Output Format: normal|json"},
+		{NULL}
+	};
+
+	argconfig_parse(argc, argv, desc, opts, &cfg, sizeof(cfg));
+	fmt = validate_output_format(cfg.output_format);
+
+	if (fmt == JSON) {
+		fprintf(stderr, "json not yet supported for eid_list\n");
+		return -EINVAL;
+	}
+
+	if (fmt != JSON && fmt != NORMAL)
+		return -EINVAL;
+
+	n = scandir(dev, &devices, scan_dev_filter, alphasort);
+	if (n <= 0)
+		return n;
+
+	list_items = calloc(n, sizeof(*list_items));
+	if (!list_items) {
+		fprintf(stderr, "can not allocate controller list payload\n");
+		return ENOMEM;
+	}
+
+	eid_num = 0;
+	for (i = 0; i < n; i++) {
+		snprintf(path, sizeof(path), "%s%s", dev, devices[i]->d_name);
+		fd = open(path, O_RDONLY);
+		ret = get_nvme_info(fd, &list_items[eid_num], path);
+		if (ret)
+			return ret;
+		if (eid_check_item(&list_items[eid_num]))
+			eid_num++;
+	}
+
+	if (eid_num > 0)
+		eid_print_list_items(list_items, eid_num);
+
+	for (i = 0; i < n; i++)
+		free(devices[i]);
+	free(devices);
+	free(list_items);
+
 	return 0;
 }
 
-static int eid_stats(int argc, char **argv, struct command *command,
+static int eid_id_ns(int argc, char **argv, struct command *command,
 		     struct plugin *plugin)
 {
-	fprintf(stderr, "%s\n", __func__);
-	return 0;
+	const char *desc = "Send an Identify Namespace command to the "\
+		"given device, returns properties of the specified namespace "\
+		"in human-readable format. Fails on non-Eideticom namespaces";
+	const char *namespace_id = "identifier of desired namespace";
+	struct nvme_id_ns ns;
+	struct stat nvme_stat;
+
+	int err, fd;
+
+	struct config {
+		__u32 namespace_id;
+	};
+
+	struct config cfg = {
+		.namespace_id    = 0,
+	};
+
+	const struct argconfig_commandline_options command_line_options[] = {
+		{"namespace-id",    'n', "NUM", CFG_POSITIVE, &cfg.namespace_id,    required_argument, namespace_id},
+		{NULL}
+	};
+
+	fd = parse_and_open(argc, argv, desc, command_line_options, &cfg, sizeof(cfg));
+	if (fd < 0)
+		return fd;
+
+	err = fstat(fd, &nvme_stat);
+	if (err < 0)
+		return err;
+
+	if (!cfg.namespace_id && S_ISBLK(nvme_stat.st_mode))
+		cfg.namespace_id = nvme_get_nsid(fd);
+	else if(!cfg.namespace_id)
+		fprintf(stderr,
+			"Error: requesting namespace-id from non-block device\n");
+
+	err = nvme_identify_ns(fd, cfg.namespace_id, 0, &ns);
+	if (!err) {
+		printf("NVME Identify Namespace %d:\n", cfg.namespace_id);
+		eid_show_nvme_id_ns(&ns);
+	}
+	else if (err > 0)
+		fprintf(stderr, "NVMe Status:%s(%x) NSID:%d\n",
+			nvme_status_to_string(err), err, cfg.namespace_id);
+	else
+		perror("identify namespace");
+	return err;
 }

--- a/eid-nvme.c
+++ b/eid-nvme.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017 Eideticom Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ *
+ *   Author: Stephen Bates <sbates@raithlin.com>
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <errno.h>
+#include <limits.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "linux/nvme_ioctl.h"
+
+#include "nvme.h"
+#include "nvme-print.h"
+#include "nvme-ioctl.h"
+#include "plugin.h"
+#include "json.h"
+
+#include "argconfig.h"
+#include "suffix.h"
+#include <sys/ioctl.h>
+#define CREATE_CMD
+#include "eid-nvme.h"
+
+static int eid_list(int argc, char **argv, struct command *command,
+		    struct plugin *plugin)
+{
+	fprintf(stderr, "%s\n", __func__);
+	return 0;
+}
+
+static int eid_stats(int argc, char **argv, struct command *command,
+		     struct plugin *plugin)
+{
+	fprintf(stderr, "%s\n", __func__);
+	return 0;
+}

--- a/eid-nvme.h
+++ b/eid-nvme.h
@@ -8,8 +8,8 @@
 
 PLUGIN(NAME("eid", "Eideticom vendor specific extensions"),
 	COMMAND_LIST(
-		ENTRY("list", "Eideticom list NoLoad namespace accelerators", eid_list)
-		ENTRY("stats", "Eideticom NoLoad internal stats", eid_stats)
+		ENTRY("list", "Eideticom NoLoad list accelerator namespaces", eid_list)
+		ENTRY("id-ns", "Eideticom NoLoad print namespace VS info", eid_id_ns)
 	)
 );
 

--- a/eid-nvme.h
+++ b/eid-nvme.h
@@ -1,0 +1,18 @@
+#undef CMD_INC_FILE
+#define CMD_INC_FILE eid-nvme
+
+#if !defined(EIDETICOM_NVME) || defined(CMD_HEADER_MULTI_READ)
+#define EIDETICOM_NVME
+
+#include "cmd.h"
+
+PLUGIN(NAME("eid", "Eideticom vendor specific extensions"),
+	COMMAND_LIST(
+		ENTRY("list", "Eideticom list NoLoad namespace accelerators", eid_list)
+		ENTRY("stats", "Eideticom NoLoad internal stats", eid_stats)
+	)
+);
+
+#endif
+
+#include "define_cmd.h"

--- a/nvme.c
+++ b/nvme.c
@@ -35,7 +35,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <math.h>
-#include <dirent.h>
 
 #include <linux/fs.h>
 
@@ -863,7 +862,7 @@ static void print_list_items(struct list_item *list_items, unsigned len)
 
 }
 
-static int get_nvme_info(int fd, struct list_item *item, const char *node)
+int get_nvme_info(int fd, struct list_item *item, const char *node)
 {
 	int err;
 
@@ -884,7 +883,7 @@ static int get_nvme_info(int fd, struct list_item *item, const char *node)
 static const char *dev = "/dev/";
 
 /* Assume every block device starting with /dev/nvme is an nvme namespace */
-static int scan_dev_filter(const struct dirent *d)
+int scan_dev_filter(const struct dirent *d)
 {
 	char path[264];
 	struct stat bd;

--- a/nvme.h
+++ b/nvme.h
@@ -18,6 +18,7 @@
 #include <stdbool.h>
 #include <endian.h>
 #include <stdint.h>
+#include <dirent.h>
 #include "plugin.h"
 #include "json.h"
 
@@ -133,5 +134,7 @@ extern const char *devicename;
 
 int __id_ctrl(int argc, char **argv, struct command *cmd, struct plugin *plugin, void (*vs)(__u8 *vs, struct json_object *root));
 int	validate_output_format(char *format);
+int get_nvme_info(int fd, struct list_item *item, const char *node);
+int scan_dev_filter(const struct dirent *d);
 
 #endif /* _NVME_H */


### PR DESCRIPTION
Finished parsing the accelerator interface data, added a human_readable option to the eideticom plugin for the status parsing. Fixed the human_readable printing alignment error when printing out vendor specific data in the normal identify namespace command with (-vH) options.